### PR TITLE
Add unicode or non-unicode support to Bulkgate

### DIFF
--- a/includes/admin/funciones-formulario.php
+++ b/includes/admin/funciones-formulario.php
@@ -71,6 +71,7 @@ $campos_de_proveedores = [
  		"usuario_bulkgate"					=> __( 'application ID', 'woocommerce-apg-sms-notifications' ),
  		"clave_bulkgate"					=> __( 'authentication Token', 'woocommerce-apg-sms-notifications' ),
  		"identificador_bulkgate"			=> __( 'sender ID', 'woocommerce-apg-sms-notifications' ),
+ 		"unicode_bulkgate"			        => __( 'unicode', 'woocommerce-apg-sms-notifications' ),
  	],
 	"bulksms" 			=> [ 
 		"usuario_bulksms" 					=> __( 'username', 'woocommerce-apg-sms-notifications' ),
@@ -233,6 +234,10 @@ $opciones_de_proveedores = [
 	"servidor_twizo"	=> [
 		"api-asia-01.twizo.com"	=> __( 'Singapore', 'woocommerce-apg-sms-notifications' ), 
 		"api-eu-01.twizo.com"	=> __( 'Germany', 'woocommerce-apg-sms-notifications' ), 
+	],
+	"unicode_bulkgate"  => [
+		1                       => __( 'Yes', 'woocommerce-apg-sms-notifications' ),
+		0                       => __( 'No', 'woocommerce-apg-sms-notifications' ),
 	],
 ];
 

--- a/includes/admin/proveedores.php
+++ b/includes/admin/proveedores.php
@@ -19,7 +19,7 @@ function apg_sms_envia_sms( $apg_sms_settings, $telefono, $mensaje ) {
  				'application_token'			=> $apg_sms_settings[ 'clave_bulkgate' ],
  				'number'					=> $telefono,
  				'text'						=> apg_sms_codifica_el_mensaje( $mensaje ),
- 				'unicode'					=> 1,
+ 				'unicode'					=> intval( $apg_sms_settings[ 'unicode_bulkgate' ] ),
  				'sender_id'					=> 'gText',
  				'sender_id_value'			=> $apg_sms_settings[ 'identificador_bulkgate' ],
  			], 'https://portal.bulkgate.com/api/1.0/simple/transactional' );


### PR DESCRIPTION
By default we were using unicode to send messages through Bulkgate, but with this setting we can now disable it and send cheaper SMS in some cases.