### PR TITLE
Add on hold messages delay in minutes

### DIFF
--- a/apg-sms.php
+++ b/apg-sms.php
@@ -311,10 +311,14 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php' ) || is_network_only_plugin
 	function apg_sms_retraso( $numero_de_pedido ) {
 		global $apg_sms_settings;
 		if ( $pedido = wc_get_order( intval( $numero_de_pedido ) ) ) {
-			$retraso_enviado = get_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', true );
-			if ( intval( $retraso_enviado ) == -1 ) {
-				update_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', 1 );
-				apg_sms_procesa_estados( $numero_de_pedido, false );
+			$estado = is_callable( [ $pedido, 'get_status' ] ) ? $pedido->get_status() : $pedido->status;
+			//Solo enviamos si no ha cambiado de estado
+			if ( $estado == 'on-hold' ) {
+				$retraso_enviado = get_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', true );
+				if ( intval( $retraso_enviado ) == -1 &&  ) {
+					update_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', 1 );
+					apg_sms_procesa_estados( $numero_de_pedido, false );
+				}
 			}
 		}
 	}

--- a/apg-sms.php
+++ b/apg-sms.php
@@ -315,7 +315,7 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php' ) || is_network_only_plugin
 			//Solo enviamos si no ha cambiado de estado
 			if ( $estado == 'on-hold' ) {
 				$retraso_enviado = get_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', true );
-				if ( intval( $retraso_enviado ) == -1 &&  ) {
+				if ( intval( $retraso_enviado ) == -1 ) {
 					update_post_meta( $numero_de_pedido, 'apg_sms_retraso_enviado', 1 );
 					apg_sms_procesa_estados( $numero_de_pedido, false );
 				}

--- a/includes/admin/funciones-formulario.php
+++ b/includes/admin/funciones-formulario.php
@@ -71,6 +71,7 @@ $campos_de_proveedores = [
  		"usuario_bulkgate"					=> __( 'application ID', 'woocommerce-apg-sms-notifications' ),
  		"clave_bulkgate"					=> __( 'authentication Token', 'woocommerce-apg-sms-notifications' ),
  		"identificador_bulkgate"			=> __( 'sender ID', 'woocommerce-apg-sms-notifications' ),
+ 		"unicode_bulkgate"			        => __( 'unicode', 'woocommerce-apg-sms-notifications' ),
  	],
 	"bulksms" 			=> [ 
 		"usuario_bulksms" 					=> __( 'username', 'woocommerce-apg-sms-notifications' ),
@@ -233,6 +234,10 @@ $opciones_de_proveedores = [
 	"servidor_twizo"	=> [
 		"api-asia-01.twizo.com"	=> __( 'Singapore', 'woocommerce-apg-sms-notifications' ), 
 		"api-eu-01.twizo.com"	=> __( 'Germany', 'woocommerce-apg-sms-notifications' ), 
+	],
+	"unicode_bulkgate"  => [
+		1                       => __( 'Yes', 'woocommerce-apg-sms-notifications' ),
+		0                       => __( 'No', 'woocommerce-apg-sms-notifications' ),
 	],
 ];
 

--- a/includes/admin/proveedores.php
+++ b/includes/admin/proveedores.php
@@ -19,7 +19,7 @@ function apg_sms_envia_sms( $apg_sms_settings, $telefono, $mensaje ) {
  				'application_token'			=> $apg_sms_settings[ 'clave_bulkgate' ],
  				'number'					=> $telefono,
  				'text'						=> apg_sms_codifica_el_mensaje( $mensaje ),
- 				'unicode'					=> 1,
+ 				'unicode'					=> intval( $apg_sms_settings[ 'unicode_bulkgate' ] ),
  				'sender_id'					=> 'gText',
  				'sender_id_value'			=> $apg_sms_settings[ 'identificador_bulkgate' ],
  			], 'https://portal.bulkgate.com/api/1.0/simple/transactional' );

--- a/includes/formulario.php
+++ b/includes/formulario.php
@@ -152,10 +152,24 @@
             ?> 
 			<tr valign="top" class="mensaje_recibido">
 				<th scope="row" class="titledesc">
+					<label for="apg_sms_settings[retraso_onhold]">
+						<?php _e( 'Order on-hold delay (minutes)', 'woocommerce-apg-sms-notifications' ); ?>:
+					</label>
+					<span class="woocommerce-help-tip" data-tip="<?php _e( 'Send this message after X minutes, if the order is still on-hold, instead of sending it immediately.', 'woocommerce-apg-sms-notifications' ); ?>"/>
+				</th>
+				<td class="forminp forminp-number">
+					<input type="text" id="apg_sms_settings[retraso_onhold]" name="apg_sms_settings[retraso_onhold]" size="50" value="<?php echo ( isset( $apg_sms_settings[ 'retraso_onhold' ] ) ) ? $apg_sms_settings[ 'retraso_onhold' ] : ''; ?>" tabindex="<?php echo $tab++; ?>"/>
+				</td>
+			</tr>
+			<tr valign="top" class="mensaje_recibido">
+				<th scope="row" class="titledesc">
 					<label for="apg_sms_settings[temporizador]">
-						<?php _e( 'Order on-hold timer', 'woocommerce-apg-sms-notifications' ); ?>:
-						<span class="woocommerce-help-tip" data-tip="<?php _e( 'You can timer this message every X hours. Leave blank to disable.', 'woocommerce-apg-sms-notifications' ); ?>"/> </th>
-				<td class="forminp forminp-number"><input type="text" id="apg_sms_settings[temporizador]" name="apg_sms_settings[temporizador]" size="50" value="<?php echo ( isset( $apg_sms_settings[ 'temporizador' ] ) ) ? $apg_sms_settings[ 'temporizador' ] : ''; ?>" tabindex="<?php echo $tab++; ?>"/>
+						<?php _e( 'Order on-hold timer (hours)', 'woocommerce-apg-sms-notifications' ); ?>:
+					</label>
+					<span class="woocommerce-help-tip" data-tip="<?php _e( 'You can timer this message every X hours. Leave blank to disable.', 'woocommerce-apg-sms-notifications' ); ?>"/>
+				</th>
+				<td class="forminp forminp-number">
+					<input type="text" id="apg_sms_settings[temporizador]" name="apg_sms_settings[temporizador]" size="50" value="<?php echo ( isset( $apg_sms_settings[ 'temporizador' ] ) ) ? $apg_sms_settings[ 'temporizador' ] : ''; ?>" tabindex="<?php echo $tab++; ?>"/>
 				</td>
 			</tr>
             <?php 


### PR DESCRIPTION
In some situations, we do not want to send the "on hold" notification right away. We may want to wait 10 or 15 minutes because the client might pay during that time, and the notification is not useful in that scenario.

We added a new "retraso" field (in minutes) and if that field is filled, the message is not sent right away but rather scheduled to run in the WordPress crowns after that amount of minutes. The message is only sent if the order is still "on hold".

This pull request also includes the previous changes (new Unicode field) for the Bulkgate gateway (sorry).